### PR TITLE
feat(URL): add absolute URL insertion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ v2.1.0/
 # AI
 .junie/
 ai_generation_assets/
+
+# DO NOT IGNORE: Assets
+!src/assets/icons/

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,19 @@
+# Credits
+
+## Icons
+- URLink Icon: [SvgRepo](https://www.svgrepo.com/svg/522220/permalink) 
+    - author: Catalin Fertu
+    - COLLECTION: Bigmug Interface Icons
+    - LICENSE: CC Attribution License
+
+
+---
+
+## Libraries
+- TipTap
+- ProseMirror
+- Vue
+- Tauri
+- ftml
+- Vite
+- ...

--- a/src/assets/icons/URLink.svg
+++ b/src/assets/icons/URLink.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    
+    <title>permalink</title>
+    <desc>Created with Sketch Beta.</desc>
+    <defs>
+
+</defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Icon-Set-Filled" sketch:type="MSLayerGroup" transform="translate(-154.000000, -724.000000)" fill="#000000">
+            <path d="M184.785,727.613 L183.355,726.184 C181.775,724.604 178.58,724.42 177,726 L170,733 C168.944,734.056 169.095,735.881 169.451,737.228 L179,728 C179.79,727.21 181.21,728.21 182,729 C182.79,729.79 183.79,731.21 183,732 L173.741,741.518 C175.088,741.873 176.944,742.056 178,741 L185,734 C186.58,732.421 186.365,729.193 184.785,727.613 L184.785,727.613 Z M162,753 C161.21,753.79 159.79,752.79 159,752 C158.21,751.21 157.21,749.79 158,749 L167.228,739.451 C165.881,739.095 164.056,738.944 163,740 L156,747 C154.42,748.58 154.604,751.775 156.184,753.354 L157.614,754.785 C159.193,756.365 162.42,756.58 164,755 L171,748 C172.056,746.944 171.874,745.088 171.518,743.741 L162,753 L162,753 Z M173.702,737.282 C173.307,736.888 172.667,736.888 172.272,737.282 L167.267,742.287 C166.872,742.683 166.872,743.322 167.267,743.718 C167.662,744.112 168.302,744.112 168.697,743.718 L173.702,738.713 C174.097,738.317 174.097,737.678 173.702,737.282 L173.702,737.282 Z" id="permalink" sketch:type="MSShapeGroup">
+
+</path>
+        </g>
+    </g>
+</svg>

--- a/src/components/editor/ToolBar/Formats.vue
+++ b/src/components/editor/ToolBar/Formats.vue
@@ -4,6 +4,8 @@ import Size from "./Formats/Size.vue";
 import Color from "./Formats/Color.vue";
 import List from "./Formats/List.vue";
 import Align from "./Formats/Align.vue";
+// Use URLFORMAT instead of URL
+import UrlFormat from "./Formats/URL.vue";
 </script>
 
 <template>
@@ -12,4 +14,5 @@ import Align from "./Formats/Align.vue";
   <Color/>
   <List/>
   <Align/>
+  <UrlFormat/>
 </template>

--- a/src/components/editor/ToolBar/Formats/URL.vue
+++ b/src/components/editor/ToolBar/Formats/URL.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import URLink from "./URL/URLink.vue";
+import URLPreview from "./URL/URLPreview.vue";
+import { insertURLinkEditor } from "../../../../stores/btnToolBar/btnFormats/btnURL/btnURLink.ts";
+
+function insertLink() {
+  insertURLinkEditor();
+}
+
+function urlIdleInterface() {}
+
+defineExpose({
+  urlIdleInterface,
+});
+</script>
+
+<template>
+  <URLink @insert="insertLink"/>
+  <URLPreview/>
+</template>

--- a/src/components/editor/ToolBar/Formats/URL/URLPreview.vue
+++ b/src/components/editor/ToolBar/Formats/URL/URLPreview.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useEditorSubscription } from "../../../../../composables/useEditorSubscription.ts";
+import { getEditor } from "../../../../../stores/editor.ts";
+
+const currentUrl = ref("");
+const hasUrl = computed(() => currentUrl.value.length > 0);
+
+function renderCurrentUrl() {
+  const editor = getEditor();
+
+  if (!editor?.isActive("link")) {
+    currentUrl.value = "";
+    return;
+  }
+
+  const href = editor.getAttributes("link").href;
+  currentUrl.value = typeof href === "string" ? href : "";
+}
+
+useEditorSubscription(renderCurrentUrl);
+</script>
+
+<template>
+  <div
+    class="format-url-site"
+    :class="{ 'is-empty': !hasUrl }"
+    :title="currentUrl"
+    aria-live="polite"
+  >
+    {{ hasUrl ? currentUrl : "" }}
+  </div>
+</template>

--- a/src/components/editor/ToolBar/Formats/URL/URLSite.vue
+++ b/src/components/editor/ToolBar/Formats/URL/URLSite.vue
@@ -1,0 +1,3 @@
+<script setup lang="ts"></script>
+
+<template></template>

--- a/src/components/editor/ToolBar/Formats/URL/URLink.vue
+++ b/src/components/editor/ToolBar/Formats/URL/URLink.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import URLink from "../../../../../assets/icons/URLink.svg";
+
+const emit = defineEmits<{
+  insert: [];
+}>();
+
+function insertLink() {
+  emit("insert");
+}
+</script>
+
+<template>
+  <button
+    class="format-basic-button url-link"
+    type="button"
+    aria-label="Insert link"
+    @click="insertLink"
+  >
+    <img :src="URLink" alt="URLink" />
+  </button>
+</template>

--- a/src/components/editor/ToolBar/NonIncludeComponents.vue
+++ b/src/components/editor/ToolBar/NonIncludeComponents.vue
@@ -8,7 +8,6 @@ import ModuleRate from "./NonIncludeComponents/ModuleRate.vue";
 import Note from "./NonIncludeComponents/Note.vue";
 import SiteURLs from "./NonIncludeComponents/SiteURLs.vue";
 import TabView from "./NonIncludeComponents/TabView.vue";
-import URLs from "./NonIncludeComponents/URLs.vue";
 import Users from "./NonIncludeComponents/Users.vue";
 </script>
 
@@ -23,7 +22,6 @@ import Users from "./NonIncludeComponents/Users.vue";
     <ModuleRate/>
     <Note/>
     <SiteURLs/>
-    <URLs/>
     <Users/>
   </div>
 </template>

--- a/src/components/editor/ToolBar/NonIncludeComponents/URLs.vue
+++ b/src/components/editor/ToolBar/NonIncludeComponents/URLs.vue
@@ -1,5 +1,0 @@
-<script setup lang="ts"></script>
-
-<template>
-  <button class="component-card">URLs</button>
-</template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import "./styles/toolbar/components/actions.css";
 import "./styles/default.css";
 import "./styles/contextmenu/menudefault.css";
 import "./styles/contextmenu/menutable.css";
+import "./styles/toolbar/url.css";
 
 connectIpc();
 createApp(App).mount("#app");

--- a/src/stores/btnToolBar/btnFormats/btnURL.ts
+++ b/src/stores/btnToolBar/btnFormats/btnURL.ts
@@ -1,0 +1,70 @@
+import {getEditor} from "../../editor.ts";
+
+function normalizeUrl(url: string) {
+    const trimmedUrl = url.trim();
+
+    if (!trimmedUrl) {
+        return "";
+    }
+
+    if (/^(?:[a-z][a-z\d+.-]*:|#|\/)/i.test(trimmedUrl)) {
+        return trimmedUrl;
+    }
+
+    return `https://${trimmedUrl}`;
+}
+
+export function getCurrentEditorLinkHref() {
+    const editor = getEditor();
+
+    if (!editor?.isActive("link")) {
+        return undefined;
+    }
+
+    return editor.getAttributes("link").href as string | undefined;
+}
+
+export function insertEditorLink(rawUrl: string) {
+    const editor = getEditor();
+    const href = normalizeUrl(rawUrl);
+
+    if (!editor || !href) {
+        return;
+    }
+
+    const { empty } = editor.state.selection;
+    const currentHref = editor.getAttributes("link").href as string | undefined;
+    const chain = editor.chain().focus();
+
+    if (empty && !currentHref) {
+        chain
+            .insertContent({
+                type: "text",
+                text: href,
+                marks: [
+                    {
+                        type: "link",
+                        attrs: { href },
+                    },
+                ],
+            })
+            .run();
+        return;
+    }
+
+    chain
+        .extendMarkRange("link")
+        .setLink({ href })
+        .run();
+}
+
+export function promptEditorLink() {
+    const currentHref = getCurrentEditorLinkHref();
+    const url = window.prompt("URL", currentHref ?? "");
+
+    if (url === null) {
+        return;
+    }
+
+    insertEditorLink(url);
+}

--- a/src/stores/btnToolBar/btnFormats/btnURL/btnURLink.ts
+++ b/src/stores/btnToolBar/btnFormats/btnURL/btnURLink.ts
@@ -1,0 +1,5 @@
+import { promptEditorLink } from "../btnURL.ts";
+
+export function insertURLinkEditor() {
+    promptEditorLink();
+}

--- a/src/stores/editor/extensions.ts
+++ b/src/stores/editor/extensions.ts
@@ -1,4 +1,5 @@
 import Underline from "@tiptap/extension-underline";
+import Link from "@tiptap/extension-link";
 import StarterKit from "@tiptap/starter-kit";
 
 import { BasicExtensions } from "./extensions/btnBasicE.ts";
@@ -17,6 +18,9 @@ export const editorExtensions = [
         codeBlock: false,
     }),
     Underline,
+    Link.configure({
+        openOnClick: false,
+    }),
     CodeBlockLowlightExtension,
     DetailsExtension,
     DetailsSummaryExtension,

--- a/src/styles/toolbar/url.css
+++ b/src/styles/toolbar/url.css
@@ -1,0 +1,50 @@
+/*
+url.css use basic buttons' styles
+variables:
+--basic-btn-left
+--basic-btn-height
+*/
+.format-basic-button.url-link {
+    left: calc(var(--basic-btn-left) + 520px);
+    z-index: 2;
+}
+
+.format-basic-button.url-link img {
+    display: block;
+    width: 16px;
+    height: 16px;
+    pointer-events: none;
+}
+
+.format-url-site {
+    width: 260px;
+    height: 26px;
+    position: absolute;
+    /* Hard code position for URL renderer */
+    left: 1500px;
+    top: 150px;
+    z-index: 1;
+
+    display: flex;
+    align-items: center;
+
+    padding: 0 8px;
+    box-sizing: border-box;
+
+    border: 1px solid var(--ribbon-dropdown-border);
+    border-radius: var(--ribbon-dropdown-radius);
+    background: var(--ribbon-dropdown-bg);
+    color: #1f2937;
+
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    pointer-events: none;
+}
+
+.format-url-site.is-empty {
+    visibility: hidden;
+}

--- a/test/non-include-test/non-include-test.ftml
+++ b/test/non-include-test/non-include-test.ftml
@@ -61,6 +61,10 @@ Aligned content
 This is a test 这是div测试文本test
 [[/div]]
 
+[!--URL test--]
+[https://scp-wiki.wikidot.com EN] [https://scp-wiki-cn.wikidot.com CN]
+[https://youtube.com youtube]
+
 @@@@
 
 [[image https://scp-wiki.wdfiles.com/local--files/theme%3Abasalt/basalt_scp_logo-for_lightmode.svg]]


### PR DESCRIPTION
docs: update credits

feat(URL): add URL place holder files

feat: add URL link format button component

feat(UI): add URL insertion button

docs: update URLink icon credits

chore: remove `URLs.vue` placeholder

chore: add placeholder files for URL components insertion

feat(URL): add URL link insertion

feat(URL): add URL link renderer

style(URL): update renderer position

refactor(URL): consolidate URL preview component

feat(URL): add promptEditorLink function for URL link editing

---

This PR only includes absolute URL support.

`URLSite.vue` is a placeholder file temporarily. 