### PR TITLE
Refactor/interpreter visibility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,48 @@
+# Copilot Instructions for SCP Foundation Editor
+
+## Build, test, and lint commands
+
+### Root frontend (Vue 3 + TipTap)
+
+- Install deps: `npm install`
+- Dev server: `npm run dev`
+- Build (includes type-check): `npm run build`
+- Preview built app: `npm run preview`
+
+### Tauri shell + Rust parser bridge
+
+- Run Tauri app in dev mode (from `src-tauri/`): `cargo tauri dev`
+- Build Tauri app (from `src-tauri/`): `cargo tauri build`
+- Build/check Rust backend crate only (from `src-tauri/`): `cargo check`
+
+### Rust parser crate (`w_parser`)
+
+- Run all tests (from `src-tauri/`): `cargo test -p w_parser`
+- Run a single test by name (from `src-tauri/`): `cargo test -p w_parser <test_name> -- --exact`
+
+### Code View subproject (`public/code_view`)
+
+- Install deps: `cd public/code_view && npm install`
+- Build CodeMirror bundle: `cd public/code_view && npm run build`
+- Lint JS files: `cd public/code_view && npm run lint`
+
+## High-level architecture
+
+- The desktop app is a **Tauri host (`src-tauri`) + Vue frontend (`src`)**. Tauri exposes commands and the Vue app calls them through `@tauri-apps/api/core` `invoke`.
+- The editor canvas is a **TipTap editor** (`src/components/editor/EditorCanvas.vue`) with extensions assembled in `src/stores/editor/extensions.ts`.
+- Editor instance access is centralized through a shared singleton (`src/stores/editor/instance.ts`), and toolbar/context-menu actions call it through small store helpers in `src/stores/btnToolBar/*` and `src/stores/btnContextMenu/*`.
+- Code View is a separate web editor loaded in an iframe from `public/code_view/index.html`, opened by Tauri command `open_code_view_window`.
+- Sync flow:
+  1. `public/code_view` posts `window.parent.postMessage({ type: "code-view-content-changed", payload })`.
+  2. Frontend listener (`src/ipc/Extensions/CodeView/SyncToParser.ts`) calls Tauri command `parse_wikidot`.
+  3. Rust command (`src-tauri/src/handlers/connect_parser.rs`) calls `w_parser::render_wikidot_to_html_and_ast`.
+  4. Returned HTML is transformed by DOM adapters (`src/ipc/Extensions/CodeView/htmlAdapter/*`) and then injected back into TipTap via `code-view-parser-html` custom event.
+- The Rust parser crate (`crates/w_parser`) wraps FTML parsing/rendering and includes an interceptor layer (`ftml_interceptor`) for Wikidot constructs that need preprocessing before FTML tokenization (currently `[[module rate]]` handling).
+
+## Key conventions in this repository
+
+- **Use explicit `.ts` import suffixes** in internal TypeScript imports (enabled by `allowImportingTsExtensions` in `tsconfig.json`).
+- **Keep editor commands in store helper modules**, not in Vue button components. Components emit UI events; store helpers execute TipTap commands via `getEditor()`.
+- **Custom TipTap nodes map to `wj-*` HTML tags** (for example tabview nodes in `TabViewE.ts`) and preserve ARIA/ID attributes for round-tripping.
+- **When Code View parser output is not directly TipTap-compatible, adapt it in `htmlAdapter` replacers** before inserting into the editor.
+- **IPC wiring is initialized from `src/main.ts` via `connectIpc()`**, so new cross-window/event integrations should be attached under `src/ipc`.

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ ftml/
 # IDE
 .vscode/
 .idea/
-.github/
 
 # Virtual environment
 .venv/
@@ -31,7 +30,7 @@ ftml/
 # Rust and Tauri
 target/
 gen/
-icons/
+icon.png
 
 # git
 .git/
@@ -45,16 +44,12 @@ Thumbs.db
 # aiderchat
 .aider*
 
-# OLD
-v2.1.0/
-
 # Vite
 .vite-dev.err.log
 .vite-dev.log
 
 # AI
 .junie/
-.forge/
 ai_generation_assets/
 personal_usage_assets/
 

--- a/crates/ltmf/src/interpreter/text/ul.rs
+++ b/crates/ltmf/src/interpreter/text/ul.rs
@@ -13,6 +13,11 @@ pub(super) fn interpret_ul(node: &Value, output: String) -> Result<String, Strin
         return Ok(output);
     }
 
+    // What's wrong with this Agent...
+    // I provided a function get_intercepted_content
+    // It's just repeat it and import???
+    // Maybe I should keep this because there's multiple listItem in ProseMirror JSON?
+    // I hate Wikidot Lists
     let output = node
         .get("content")
         .and_then(Value::as_array)

--- a/crates/ltmf/src/preprocess/normalize.rs
+++ b/crates/ltmf/src/preprocess/normalize.rs
@@ -36,7 +36,7 @@ mod normalize_raw_text;
 mod normalize_strike;
 mod normalize_tabview;
 mod normalize_white_space_pre_wrap;
-pub mod rename;
+mod rename;
 // pub mod normalize_div;
 
 pub fn normalize(value: Value) -> Value {

--- a/crates/ltmf/src/preprocess/normalize/normalize_bullet_list.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_bullet_list.rs
@@ -1,6 +1,6 @@
 use crate::preprocess::normalize::rename::rename_type;
 use serde_json::Value;
 
-pub fn normalize_bullet_list(value: Value) -> Value {
+pub(super) fn normalize_bullet_list(value: Value) -> Value {
     rename_type(value, "bulletList", "unorderedList")
 }

--- a/crates/ltmf/src/preprocess/normalize/normalize_color_text_marks.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_color_text_marks.rs
@@ -1,7 +1,7 @@
 use crate::preprocess::normalize::rename::rename_type;
 use serde_json::Value;
 
-pub fn normalize_color_text_marks(value: Value) -> Value {
+pub(super) fn normalize_color_text_marks(value: Value) -> Value {
     let value = rename_type(value, "textColor", "ColorText");
     normalize_color_text_attrs(value)
 }

--- a/crates/ltmf/src/preprocess/normalize/normalize_details.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_details.rs
@@ -8,7 +8,7 @@ fn rename_details(value: Value) -> Value {
     rename_type(value, "detailsContent", "CollapsibleContent")
 }
 
-pub fn normalize_details(value: Value) -> Value {
+pub(super) fn normalize_details(value: Value) -> Value {
     let value = rename_details(value);
     remove_collapsible_attrs(value)
 }

--- a/crates/ltmf/src/preprocess/normalize/normalize_div.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_div.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
 
-pub fn normalize_div(value: Value) -> Value {
+pub(super) fn normalize_div(value: Value) -> Value {
     todo!()
 }

--- a/crates/ltmf/src/preprocess/normalize/normalize_empty_paragraph_between_newline.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_empty_paragraph_between_newline.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn normalize_empty_paragraph_between_newline(value: Value) -> Value {
+pub(super) fn normalize_empty_paragraph_between_newline(value: Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()

--- a/crates/ltmf/src/preprocess/normalize/normalize_font_size.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_font_size.rs
@@ -1,6 +1,6 @@
 use crate::preprocess::normalize::rename::rename_type;
 use serde_json::Value;
 
-pub fn normalize_font_size(value: Value) -> Value {
+pub(super) fn normalize_font_size(value: Value) -> Value {
     rename_type(value, "fontSize", "Size")
 }

--- a/crates/ltmf/src/preprocess/normalize/normalize_footnote.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_footnote.rs
@@ -2,7 +2,7 @@
 // Also, it will add the type "footnote" to footnote ref contents.
 use serde_json::Value;
 
-pub fn normalize_footnote(value: Value) -> Value {
+pub(super) fn normalize_footnote(value: Value) -> Value {
     match value {
         Value::Object(map) => {
             let value = Value::Object(map);

--- a/crates/ltmf/src/preprocess/normalize/normalize_force_new_line.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_force_new_line.rs
@@ -1,6 +1,6 @@
 use crate::preprocess::normalize::rename::rename_type;
 use serde_json::Value;
 
-pub fn normalize_force_new_line_to_paragraph(value: Value) -> Value {
+pub(super) fn normalize_force_new_line_to_paragraph(value: Value) -> Value {
     rename_type(value, "ForceNewLine", "paragraph")
 }

--- a/crates/ltmf/src/preprocess/normalize/normalize_hard_break.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_hard_break.rs
@@ -2,6 +2,6 @@
 use crate::preprocess::normalize::rename::rename_type;
 use serde_json::Value;
 
-pub fn normalize_hard_break(value: Value) -> Value {
+pub(super) fn normalize_hard_break(value: Value) -> Value {
     rename_type(value, "hardBreak", "NewLine")
 }

--- a/crates/ltmf/src/preprocess/normalize/normalize_horizontalrule.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_horizontalrule.rs
@@ -2,6 +2,6 @@
 use crate::preprocess::normalize::rename::rename_type;
 use serde_json::Value;
 
-pub fn normalize_horizontalrule(value: Value) -> serde_json::Value {
+pub(super) fn normalize_horizontalrule(value: Value) -> serde_json::Value {
     rename_type(value, "horizontalRule", "HorizontalRule")
 }

--- a/crates/ltmf/src/preprocess/normalize/normalize_include.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_include.rs
@@ -2,7 +2,7 @@
 // This function recursively normalizes matching wjBlockTag nodes to Include.
 use serde_json::Value;
 
-pub fn normalize_include(value: Value) -> Value {
+pub(super) fn normalize_include(value: Value) -> Value {
     match value {
         Value::Object(mut map) => {
             let is_include = is_include_node(&Value::Object(map.clone()));

--- a/crates/ltmf/src/preprocess/normalize/normalize_new_line_marks.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_new_line_marks.rs
@@ -1,7 +1,7 @@
 // This function will normalize has attrs/marks Newline type into normal Newline
 use serde_json::Value;
 
-pub fn normalize_new_line_marks(value: Value) -> Value {
+pub(super) fn normalize_new_line_marks(value: Value) -> Value {
     match value {
         Value::Object(mut map) => {
             let is_new_line = map.get("type").and_then(Value::as_str) == Some("NewLine");

--- a/crates/ltmf/src/preprocess/normalize/normalize_note.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_note.rs
@@ -1,7 +1,7 @@
 // This function will remove note json attrs and change the type to Note
 use serde_json::Value;
 
-pub fn normalize_note(value: Value) -> Value {
+pub(super) fn normalize_note(value: Value) -> Value {
     match value {
         Value::Object(mut map) => {
             let is_note = is_note_node(&Value::Object(map.clone()));

--- a/crates/ltmf/src/preprocess/normalize/normalize_raw_text.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_raw_text.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn normalize_raw_text(value: Value) -> Value {
+pub(super) fn normalize_raw_text(value: Value) -> Value {
     match value {
         Value::Object(map) => {
             let value = Value::Object(map);

--- a/crates/ltmf/src/preprocess/normalize/normalize_strike.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_strike.rs
@@ -2,6 +2,6 @@
 use crate::preprocess::normalize::rename::rename_type;
 use serde_json::Value;
 
-pub fn normalize_strike(value: Value) -> Value {
+pub(super) fn normalize_strike(value: Value) -> Value {
     rename_type(value, "strike", "Strikethrough")
 }

--- a/crates/ltmf/src/preprocess/normalize/normalize_tabview.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_tabview.rs
@@ -1,7 +1,7 @@
 use crate::preprocess::normalize::rename::rename_type;
 use serde_json::Value;
 
-pub fn normalize_tabview(value: Value) -> Value {
+pub(super) fn normalize_tabview(value: Value) -> Value {
     let value = rename_type(value, "tabViewButton", "Tab");
     let value = rename_type(value, "tabViewButtonList", "TabViewButtonList");
     let value = rename_type(value, "tabViewPanel", "TabViewContent");

--- a/crates/ltmf/src/preprocess/normalize/normalize_white_space_pre_wrap.rs
+++ b/crates/ltmf/src/preprocess/normalize/normalize_white_space_pre_wrap.rs
@@ -13,7 +13,7 @@
 //         },
 use serde_json::Value;
 
-pub fn normalize_white_space_pre_wrap(value: Value) -> Value {
+pub(super) fn normalize_white_space_pre_wrap(value: Value) -> Value {
     match value {
         Value::Object(map) => {
             let value = Value::Object(map);

--- a/crates/ltmf/src/preprocess/normalize/rename.rs
+++ b/crates/ltmf/src/preprocess/normalize/rename.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub(crate) fn rename_type(value: Value, from: &str, to: &str) -> Value {
+pub(super) fn rename_type(value: Value, from: &str, to: &str) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()

--- a/crates/ltmf/src/preprocess/sanitize.rs
+++ b/crates/ltmf/src/preprocess/sanitize.rs
@@ -23,7 +23,7 @@ mod sanitize_pm_unused_img;
 mod sanitize_table;
 mod sanitize_tabview;
 mod sanitize_text_align;
-pub mod sanitize_unused_code_block_attrs_class;
+mod sanitize_unused_code_block_attrs_class;
 mod sanitize_unused_img_attrs;
 mod sanitize_unused_toc_id;
 mod sanitize_url;

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_contenteditable.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_contenteditable.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_contenteditable(value: Value) -> Value {
+pub(super) fn sanitize_contenteditable(value: Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_data_editor.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_data_editor.rs
@@ -3,8 +3,8 @@ use serde_json::Value;
 // Sanitize some unuseful data-editor when export to wikitext
 use crate::preprocess::sanitize::sanitize_data_editor::no_resize::sanitize_data_editor_no_resize;
 
-pub mod no_resize;
+pub(super) mod no_resize;
 
-pub fn sanitize_data_editor(value: Value) -> Value {
+pub(super) fn sanitize_data_editor(value: Value) -> Value {
     sanitize_data_editor_no_resize(value)
 }

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_data_editor/no_resize.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_data_editor/no_resize.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_data_editor_no_resize(value: Value) -> Value {
+pub(super) fn sanitize_data_editor_no_resize(value: Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_draggable.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_draggable.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_draggable(value: Value) -> Value {
+pub(super) fn sanitize_draggable(value: Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_empty_attrs.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_empty_attrs.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_empty_attrs(value: &Value) -> Value {
+pub(super) fn sanitize_empty_attrs(value: &Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_empty_html_attrs.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_empty_html_attrs.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_empty_html_attrs(value: &Value) -> Value {
+pub(super) fn sanitize_empty_html_attrs(value: &Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_footnote.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_footnote.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_footnote_refs(value: Value) -> Value {
+pub(super) fn sanitize_footnote_refs(value: Value) -> Value {
     sanitize_value(value).unwrap_or(Value::Null)
 }
 

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_null.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_null.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_null(value: &Value) -> Value {
+pub(super) fn sanitize_null(value: &Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_pm_unused_img.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_pm_unused_img.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_pm_unused_img(value: Value) -> Value {
+pub(super) fn sanitize_pm_unused_img(value: Value) -> Value {
     sanitize_value(value).unwrap_or(Value::Null)
 }
 

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_table.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_table.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_table(value: Value) -> Value {
+pub(super) fn sanitize_table(value: Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_tabview.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_tabview.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-pub mod is_tabview;
-pub mod sanitize_tabindex;
-pub mod sanitize_tabview_aria;
-pub mod sanitize_tabview_attrs;
-pub mod sanitize_tabview_hidden;
-pub mod sanitize_tabview_id;
-pub mod sanitize_tabview_role;
+mod is_tabview;
+mod sanitize_tabindex;
+mod sanitize_tabview_aria;
+mod sanitize_tabview_attrs;
+mod sanitize_tabview_hidden;
+mod sanitize_tabview_id;
+mod sanitize_tabview_role;
 
 use sanitize_tabindex::sanitize_tabindex;
 use sanitize_tabview_aria::sanitize_tabview_aria;
@@ -15,7 +15,7 @@ use sanitize_tabview_hidden::sanitize_tabview_hidden;
 use sanitize_tabview_id::sanitize_tabview_id;
 use sanitize_tabview_role::sanitize_tabview_role;
 
-pub fn sanitize_tabview(value: Value) -> Value {
+pub(super) fn sanitize_tabview(value: Value) -> Value {
     let value = sanitize_tabview_aria(value);
     let value = sanitize_tabview_attrs(&value);
     let value = sanitize_tabview_id(value);

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/is_tabview.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/is_tabview.rs
@@ -1,6 +1,6 @@
 use serde_json::{Map, Value};
 
-pub fn is_tabview(map: &Map<String, Value>) -> bool {
+pub(super) fn is_tabview(map: &Map<String, Value>) -> bool {
     map.get("attrs")
         .and_then(|attrs| attrs.get("class"))
         .and_then(Value::as_str)

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabindex.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabindex.rs
@@ -1,7 +1,7 @@
 use super::is_tabview::is_tabview;
 use serde_json::Value;
 
-pub fn sanitize_tabindex(value: Value) -> Value {
+pub(super) fn sanitize_tabindex(value: Value) -> Value {
     sanitize_tabindex_in_tabview(value, false)
 }
 

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_aria.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_aria.rs
@@ -89,7 +89,7 @@ fn sanitize_aria_labelledby(value: Value) -> Value {
     sanitize_aria_labelledby_in_tabview(value, false)
 }
 
-pub fn sanitize_tabview_aria(value: Value) -> Value {
+pub(super) fn sanitize_tabview_aria(value: Value) -> Value {
     let value = sanitize_aria_controls(value);
     let value = sanitize_aria_labelledby(value);
     sanitize_aria_selected(value)

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_attrs.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_attrs.rs
@@ -14,7 +14,7 @@ fn is_tabview_button_list_attrs(value: &Value) -> bool {
     })
 }
 
-pub fn sanitize_tabview_attrs(json: &Value) -> Value {
+pub(super) fn sanitize_tabview_attrs(json: &Value) -> Value {
     match json {
         Value::Object(map) => Value::Object(
             map.iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_hidden.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_hidden.rs
@@ -1,7 +1,7 @@
 use super::is_tabview::is_tabview;
 use serde_json::Value;
 
-pub fn sanitize_tabview_hidden(value: Value) -> Value {
+pub(super) fn sanitize_tabview_hidden(value: Value) -> Value {
     sanitize_tabview_hidden_in_tabview(value, false)
 }
 

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_id.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_id.rs
@@ -1,7 +1,7 @@
 use super::is_tabview::is_tabview;
 use serde_json::Value;
 
-pub fn sanitize_tabview_id(value: Value) -> Value {
+pub(super) fn sanitize_tabview_id(value: Value) -> Value {
     sanitize_tabview_id_in_tabview(value, false)
 }
 

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_role.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_tabview/sanitize_tabview_role.rs
@@ -1,7 +1,7 @@
 use super::is_tabview::is_tabview;
 use serde_json::Value;
 
-pub fn sanitize_tabview_role(value: Value) -> Value {
+pub(super) fn sanitize_tabview_role(value: Value) -> Value {
     sanitize_tabview_role_in_tabview(value, false)
 }
 

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_text_align.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_text_align.rs
@@ -35,7 +35,7 @@ fn sanitize_style(value: &Value, style: &str) -> Value {
     }
 }
 
-pub fn sanitize_text_align(value: Value) -> Value {
+pub(super) fn sanitize_text_align(value: Value) -> Value {
     let value = sanitize_text_align_left(&value);
     let value = sanitize_text_align_center(&value);
     sanitize_text_align_right(&value)

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_unused_code_block_attrs_class.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_unused_code_block_attrs_class.rs
@@ -1,6 +1,6 @@
 use serde_json::{Map, Value};
 
-pub fn sanitize_unused_code_block_attrs_class(value: Value) -> Value {
+pub(super) fn sanitize_unused_code_block_attrs_class(value: Value) -> Value {
     match value {
         Value::Object(map) => sanitize_object(map),
         Value::Array(values) => Value::Array(

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_unused_img_attrs.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_unused_img_attrs.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_unused_img_attrs(value: Value) -> Value {
+pub(super) fn sanitize_unused_img_attrs(value: Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_unused_toc_id.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_unused_toc_id.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_unused_toc_id(value: Value) -> Value {
+pub(super) fn sanitize_unused_toc_id(value: Value) -> Value {
     match value {
         Value::Object(mut map) => {
             if is_heading(&map) {

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_url.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_url.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn sanitize_url(value: Value) -> Value {
+pub(super) fn sanitize_url(value: Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()

--- a/crates/ltmf/src/preprocess/sanitize/sanitize_wj_inline_tag.rs
+++ b/crates/ltmf/src/preprocess/sanitize/sanitize_wj_inline_tag.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 /// Sanitize `wjInlineTag` function only sanitize the `type` field.
 /// Because `wjInlineTag` is only used for TipTap/ProseMirror editor allowing ftml's customize HTML tags
-pub fn sanitize_wj_inline_tag(value: Value) -> Value {
+pub(super) fn sanitize_wj_inline_tag(value: Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()


### PR DESCRIPTION
This PR related to refactor interpreter visibility.

Most refactor based on:

from `pub fn` to `pub(crate) fn` or `pub(super) fn`.

Also, this refactor removed some unnecessary ignores in `.gitignore` and add some comments.