### PR TITLE
style(editor-theme): add div hover and selectednode in-editor marks

### DIFF
--- a/src/styles/theme/default.scss
+++ b/src/styles/theme/default.scss
@@ -429,6 +429,18 @@
           }
         }
       }
+
+      // This hover mark `div` blocks
+      &:hover {
+        border: var(--wikidot-red) solid 1px;
+        border-radius: 5px;
+      }
+
+      // This selectednode mark `div` when user select it
+      &.ProseMirror-selectednode {
+        border: var(--color-word-blue) solid 1px;
+        border-radius: 5px;
+      }
     }
 
     // User and User with img part are all mutable


### PR DESCRIPTION
It's impossible to work on a branch that behind CSS support.

I could not implement anything besides styles.

When create a new file, I need to check everything I did last time.

I'll merge this without any review and create a new div branch for other implementation.