### PR TITLE
feat(font-size): update font sizes array, remove unused script

### DIFF
--- a/scripts/calculator/UI_calculator_toolbar_basic_buttons.py
+++ b/scripts/calculator/UI_calculator_toolbar_basic_buttons.py
@@ -1,9 +1,0 @@
-# A very simple calculator only for implementation
-
-a = input("Input number for basic buttons\n")
-a = int(a)
-
-for i in range(10):
-    b = i + 1
-    c = a * b
-    print("\n", c)

--- a/src/components/editor/ToolBar/Formats/Size/ListSize.vue
+++ b/src/components/editor/ToolBar/Formats/Size/ListSize.vue
@@ -9,7 +9,10 @@ const emit = defineEmits<{
 
 const defaultFontSize = 16;
 const isOpen = ref(false);
-const fontSizes = [12, 14];
+const fontSizes = [
+    8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    27, 28, 29, 30,
+]; // HardCoded font sizes haha
 const selectedSize = ref(defaultFontSize);
 
 function parseFontSize(size: unknown) {


### PR DESCRIPTION
## What's changed:
- Add hardcoded font sizes list

Why not using TipTap dependency: 
Because there's no font size library dependency in `TipTapv3.22.5`

- Remove unused script (remove some unused python calculators)
