### PR TITLE
fix(hardBreak): add hardBreak/new-paragraph Enter extension

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": {
+    "github@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,9 @@
       "Bash(node *)",
       "Bash(grep -n \"^\\\\.\\\\|^[a-z#].*{$\\\\|wj-footnote-list {\" src/styles/theme/default.scss)",
       "Bash(awk -F: '$1<594')",
-      "Bash(git commit *)"
+      "Bash(git commit *)",
+      "PowerShell(npx vue-tsc --noEmit 2>&1 | Select-Object -First 40)",
+      "PowerShell(git add *)"
     ]
   },
   "skillOverrides": {

--- a/src/stores/editor/extensions.ts
+++ b/src/stores/editor/extensions.ts
@@ -10,6 +10,7 @@ import {
 } from "./extensions/DetailsE.ts";
 import { DetailsContentExtension } from "./extensions/DetailsContentE.ts";
 import { FontSizeExtension } from "./extensions/FontSizeE.ts";
+import { HardBreakAndNewParagraphExtension } from "./extensions/hardBreakandNewParagraphE.ts";
 import { ImageExtension } from "./extensions/ImageE.ts";
 import InvisibleCharacters, {
     ParagraphNode,
@@ -51,4 +52,5 @@ export const editorExtensions = [
     UserExtension,
     UserWithImgExtension,
     WJTagExtension,
+    HardBreakAndNewParagraphExtension,
 ];

--- a/src/stores/editor/extensions/hardBreakandNewParagraphE.ts
+++ b/src/stores/editor/extensions/hardBreakandNewParagraphE.ts
@@ -1,0 +1,79 @@
+import { Extension } from "@tiptap/core";
+import type { ResolvedPos } from "@tiptap/pm/model";
+
+import { nodeHasClass } from "./WJtags/htmlPreserveE.ts";
+
+// Single Enter inserts a `hardBreak` (exported as a Wikidot `NewLine`); a second
+// Enter promotes the provisional break into a real paragraph split. This inverts
+// ProseMirror's default Enter behavior to match Wikidot line-break semantics.
+
+const EXCLUDED_ANCESTOR_TYPES = ["listItem", "tableCell", "tableHeader"];
+const IMAGE_CAPTION_CLASS = "scp-image-caption";
+
+// Returns true when the cursor sits inside a context that owns its own Enter
+// behavior (lists, table cells, image captions), so we leave it untouched.
+function hasExcludedAncestor($from: ResolvedPos) {
+    for (let depth = $from.depth; depth > 0; depth -= 1) {
+        const node = $from.node(depth);
+
+        if (EXCLUDED_ANCESTOR_TYPES.includes(node.type.name)) {
+            return true;
+        }
+
+        if (nodeHasClass(node, IMAGE_CAPTION_CLASS)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export const HardBreakAndNewParagraphExtension = Extension.create({
+    name: "hardBreakAndNewParagraph",
+
+    addKeyboardShortcuts() {
+        return {
+            Enter: () => {
+                const { selection } = this.editor.state;
+
+                // Only handle a plain collapsed caret; selections fall through to
+                // the default replace-and-split behavior.
+                if (!selection.empty) {
+                    return false;
+                }
+
+                const { $from } = selection;
+
+                // Only act inside ordinary paragraphs; everything else (headings,
+                // code blocks, details summary, tabview buttons, lists, table
+                // cells, captions) keeps its existing Enter handling.
+                if ($from.parent.type.name !== "paragraph") {
+                    return false;
+                }
+
+                if (hasExcludedAncestor($from)) {
+                    return false;
+                }
+
+                const nodeBefore = $from.nodeBefore;
+
+                if (nodeBefore?.type.name === "hardBreak") {
+                    // Double Enter: drop the provisional hardBreak, then split so
+                    // the exporter sees a clean paragraph boundary (no stray
+                    // trailing NewLine / blank line).
+                    return this.editor
+                        .chain()
+                        .deleteRange({
+                            from: $from.pos - nodeBefore.nodeSize,
+                            to: $from.pos,
+                        })
+                        .splitBlock()
+                        .run();
+                }
+
+                // Single Enter: insert a hardBreak (Wikidot newline).
+                return this.editor.commands.setHardBreak();
+            },
+        };
+    },
+});


### PR DESCRIPTION
## What's Changed?

Invert default Enter semantics for Wikidot: single Enter inserts a hardBreak (exported as a NewLine); a second Enter promotes the provisional break into a paragraph split, deleting the break first so the exporter sees no stray trailing NewLine.

Only acts on a collapsed caret in an ordinary paragraph; bails out in lists, table cells, image captions, and any non-paragraph textblock so existing Enter handlers (details, tabview, lists, captions) are untouched.
