### PR TITLE
float image exporter support

### DIFF
--- a/crates/ltmf/src/interpret/CONTEXT.MD
+++ b/crates/ltmf/src/interpret/CONTEXT.MD
@@ -7,7 +7,6 @@ The interpreter is not finished yet. The resourcepack includer is implemented, b
 Currently, the interpreter can handle most marks in ProseMirror JSON, as well as some URLs and ProseMirror attrs.
 
 TODO:
-
 - [x] Implement user div exporter
 - [x] Implement user css exporter
 - [ ] Implement user span exporter
@@ -15,3 +14,12 @@ TODO:
 - [x] Test the interpreter: attempt 1: test normal text and components
 - [x] Add `[[footnoteblock]]` exporter (Fixed, only a patch is needed)
 - [x] Add `Content Paragraph` exporter
+
+
+### About float Image
+
+The float image interpreter is implemented, but the parser sometimes loses metadata like `floatleft` or `floatright`.
+
+However, this issue doesn't affect `component:image-block`, which is the most commonly used case, so the interpreter works fine in practice.
+
+**Not planned to fix:** Adding more patches would introduce additional maintenance burden. When the upstream parser eventually fixes this issue, our patches might cause double parsing or duplicate metadata, requiring another refactor.

--- a/crates/ltmf/src/interpret/wiki_component/image.rs
+++ b/crates/ltmf/src/interpret/wiki_component/image.rs
@@ -14,6 +14,8 @@ pub(super) fn interpret_image(node: &Value, output: String) -> Result<String, St
         Some(ImageAlignment::Left) => format!("[[<image {src}{options}]]"),
         Some(ImageAlignment::Right) => format!("[[>image {src}{options}]]"),
         Some(ImageAlignment::Center) => format!("[[=image {src}{options}]]"),
+        Some(ImageAlignment::FloatLeft) => format!("[[f<image {src}{options}]]"),
+        Some(ImageAlignment::FloatRight) => format!("[[f>image {src}{options}]]"),
         None => format!("[[image {src}{options}]]"),
     })
 }
@@ -26,6 +28,8 @@ enum ImageAlignment {
     Left,
     Right,
     Center,
+    FloatLeft,
+    FloatRight,
 }
 
 fn image_src(node: &Value) -> Option<&str> {
@@ -82,6 +86,14 @@ fn image_alignment(node: &Value) -> Option<ImageAlignment> {
         .get("wrapperAttributes")?
         .get("class")?
         .as_str()?;
+
+    if class_has_token(class, "floatleft") {
+        return Some(ImageAlignment::FloatLeft);
+    }
+
+    if class_has_token(class, "floatright") {
+        return Some(ImageAlignment::FloatRight);
+    }
 
     if class_has_token(class, "alignleft") {
         return Some(ImageAlignment::Left);
@@ -141,6 +153,80 @@ mod tests {
         assert_eq!(
             interpret_image(&node, String::new()).unwrap(),
             r#"[[image example.png width="457px"]]"#
+        );
+    }
+
+    #[test]
+    fn interprets_floatleft_image() {
+        let node = json!({
+            "type": "image",
+            "attrs": {
+                "src": "example.png",
+                "wrapperAttributes": {
+                    "class": "image-container floatleft"
+                }
+            }
+        });
+
+        assert_eq!(
+            interpret_image(&node, String::new()).unwrap(),
+            "[[f<image example.png]]"
+        );
+    }
+
+    #[test]
+    fn interprets_floatleft_image_with_width_and_height() {
+        let node = json!({
+            "type": "image",
+            "attrs": {
+                "src": "example.png",
+                "wrapperAttributes": {
+                    "class": "image-container floatleft",
+                    "style": "width: 457px; height: 437px;"
+                }
+            }
+        });
+
+        assert_eq!(
+            interpret_image(&node, String::new()).unwrap(),
+            r#"[[f<image example.png width="457px" height="437px"]]"#
+        );
+    }
+
+    #[test]
+    fn interprets_floatright_image() {
+        let node = json!({
+            "type": "image",
+            "attrs": {
+                "src": "example.png",
+                "wrapperAttributes": {
+                    "class": "image-container floatright"
+                }
+            }
+        });
+
+        assert_eq!(
+            interpret_image(&node, String::new()).unwrap(),
+            "[[f>image example.png]]"
+        );
+    }
+
+    #[test]
+    fn interprets_floatright_image_with_width_and_height() {
+        let node = json!({
+            "type": "image",
+            "attrs": {
+                "src": "example.png",
+                "wrapperAttributes": {
+                    "class": "image-container floatright",
+                    "style": "width: 457px; height: 437px;"
+                }
+            }
+        });
+
+        assert_eq!(
+            interpret_image(&node, String::new()).unwrap(),
+            r#"[[f>image example.png width="457px" height="437px"]]"#
         );
     }
 }

--- a/docs/TODO/bugs.md
+++ b/docs/TODO/bugs.md
@@ -7,8 +7,8 @@
 5. ~~`[[image]]` block generator missed the `width` attribute.~~
 6. ~~`[[module css]]` has been blocked to insert in the editor.~~
 7. ~~`[[collapsible]]` `+-` string need to be escaped.~~
-8. `[[f> image url]]` is not supported yet.
+8. ~~`[[f> image url]]` is not supported yet.~~
 9. `[[module rate]]` is not supported yet.
 10. ~~`caption` variable is not supported yet.~~
-11. `[[footnote]]` needs better editor experience support.
-12. ftml output for `@@@@` needs to be adapted in editor.
+11. ~~`[[footnote]]` needs better editor experience support.~~
+12. ~~ftml output for `@@@@` needs to be adapted in editor.~~


### PR DESCRIPTION
## What's Changed:
- Add float image exporter support
- Explain image metadata losing issue and mark as not planned

---

### Quick Review:
The float image interpreter is implemented, but the parser sometimes loses metadata like `floatleft` or `floatright`.

However, this issue doesn't affect `component:image-block`, which is the most commonly used case, so the interpreter works fine in practice.

_**Not planned to fix:**_ 
Adding more patches would introduce additional maintenance burden. When the upstream parser eventually fixes this issue, our patches might cause double parsing or duplicate metadata, requiring another refactor.
