### PR TITLE
Fix/footnoteblock formats

### DIFF
--- a/crates/ltmf/src/ftml_fmt.rs
+++ b/crates/ltmf/src/ftml_fmt.rs
@@ -3,10 +3,12 @@ mod add_module_rate;
 mod add_user_css;
 mod fmt_alignments;
 mod fmt_newline;
+mod remove_trailing_break_force_newline;
 
 use crate::ftml_fmt::add_footnote_block::add_footnote_block;
 use crate::ftml_fmt::add_module_rate::add_module_rate;
 use crate::ftml_fmt::add_user_css::add_user_css;
+use crate::ftml_fmt::remove_trailing_break_force_newline::remove_trailing_break_force_newline;
 use crate::ftml_fmt::{fmt_alignments::format_alignments, fmt_newline::format_newline};
 use crate::paths::temp_dir;
 use std::fs;
@@ -42,6 +44,9 @@ pub fn ftml_fmt(ftml: &str) -> String {
 
     // add footnote block
     let output = add_footnote_block(&output);
+
+    // remove trailing break force newline
+    let output = remove_trailing_break_force_newline(&output);
 
     // write output to interpreter's temp output file back
     if read_ftml.is_ok() {

--- a/crates/ltmf/src/ftml_fmt/remove_trailing_break_force_newline.rs
+++ b/crates/ltmf/src/ftml_fmt/remove_trailing_break_force_newline.rs
@@ -1,0 +1,38 @@
+/// Removes only the last `@@@@` (forced newline) token from the ftml string.
+/// Earlier `@@@@` tokens are left untouched; if none exist the input is returned as-is.
+pub(super) fn remove_trailing_break_force_newline(ftml: &str) -> String {
+    match ftml.rfind("@@@@") {
+        Some(index) => {
+            let mut output = String::with_capacity(ftml.len());
+            output.push_str(&ftml[..index]);
+            output.push_str(&ftml[index + "@@@@".len()..]);
+            output
+        }
+        None => ftml.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removes_the_only_token() {
+        assert_eq!(remove_trailing_break_force_newline("a@@@@b"), "ab");
+    }
+
+    #[test]
+    fn removes_only_the_last_token() {
+        assert_eq!(remove_trailing_break_force_newline("@@@@x@@@@y"), "@@@@xy");
+    }
+
+    #[test]
+    fn leaves_string_without_token_unchanged() {
+        assert_eq!(remove_trailing_break_force_newline("abc"), "abc");
+    }
+
+    #[test]
+    fn removes_trailing_token() {
+        assert_eq!(remove_trailing_break_force_newline("a\n@@@@"), "a\n");
+    }
+}

--- a/src/stores/editor/extensions/WJtags/FootnoteE.ts
+++ b/src/stores/editor/extensions/WJtags/FootnoteE.ts
@@ -671,53 +671,6 @@ export function renumberFootnotes(transaction: Transaction) {
     return operations.length > 0;
 }
 
-function isEmptyParagraphNode(node: ProseMirrorNode) {
-    return (
-        node.type.name === "paragraph" && node.textContent.trim().length === 0
-    );
-}
-
-export function ensureFootnoteListLeadingBlankLine(transaction: Transaction) {
-    const paragraphNode = transaction.doc.type.schema.nodes.paragraph;
-
-    if (!paragraphNode) {
-        return false;
-    }
-
-    let footnoteListPos: number | null = null;
-    let previousNode: ProseMirrorNode | null = null;
-    let offset = 0;
-
-    for (let index = 0; index < transaction.doc.childCount; index += 1) {
-        const child = transaction.doc.child(index);
-
-        if (nodeHasClass(child, "wj-footnote-list")) {
-            footnoteListPos = offset;
-            break;
-        }
-
-        previousNode = child;
-        offset += child.nodeSize;
-    }
-
-    if (
-        footnoteListPos === null ||
-        (previousNode && isEmptyParagraphNode(previousNode))
-    ) {
-        return false;
-    }
-
-    const blankParagraph = paragraphNode.createAndFill();
-
-    if (!blankParagraph) {
-        return false;
-    }
-
-    transaction.insert(footnoteListPos, blankParagraph);
-
-    return true;
-}
-
 export function findClosestEmptyFootnoteContentsSelection(
     doc: ProseMirrorNode,
     pos: number,

--- a/src/stores/editor/extensions/WJtags/FootnoteSyncE.ts
+++ b/src/stores/editor/extensions/WJtags/FootnoteSyncE.ts
@@ -5,7 +5,6 @@ import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 
 import {
     collectFootnoteDocumentInfo,
-    ensureFootnoteListLeadingBlankLine,
     findClosestEmptyFootnoteContentsSelection,
     getDeletedFootnoteRefKeys,
     getFootnoteListItemDeletionRanges,
@@ -57,8 +56,6 @@ export function createFootnoteSyncPlugin() {
                     }
                 }
 
-                ensureFootnoteListLeadingBlankLine(transaction);
-
                 return transaction;
             }
 
@@ -80,17 +77,13 @@ export function createFootnoteSyncPlugin() {
                 });
 
                 renumberFootnotes(transaction);
-                ensureFootnoteListLeadingBlankLine(transaction);
 
                 return transaction;
             }
 
             const renumberTransaction = newState.tr;
 
-            if (
-                renumberFootnotes(renumberTransaction) ||
-                ensureFootnoteListLeadingBlankLine(renumberTransaction)
-            ) {
+            if (renumberFootnotes(renumberTransaction)) {
                 return renumberTransaction;
             }
 
@@ -133,7 +126,7 @@ export function createFootnoteSyncPlugin() {
                     changed = true;
                 });
 
-            if (!changed && !ensureFootnoteListLeadingBlankLine(transaction)) {
+            if (!changed) {
                 return null;
             }
 


### PR DESCRIPTION
## Description

Closes #95

---

## Type of change

- [x] Bug fix

---

## Checklist

- [x] `cargo check --workspace` passes
- [x] Export output tested against relevant Wikidot syntax (paste input/output below if applicable)
- [x] No inline SQL added — `.sql` files used throughout
- [x] No unnecessary dependencies added
- [x] `wj-*` attributes and round-trip behavior preserved (if touching TipTap node extensions)

---

## Export behavior

**Does this PR change or break existing Wikidot export output?**

- [x] No
