### PR TITLE
Fix/macos/input window

### DIFF
--- a/crates/ltmf/src/ftml_fmt/remove_trailing_break_force_newline.rs
+++ b/crates/ltmf/src/ftml_fmt/remove_trailing_break_force_newline.rs
@@ -1,6 +1,14 @@
+use regex::Regex;
+
 /// Removes only the last `@@@@` (forced newline) token from the ftml string.
 /// Earlier `@@@@` tokens are left untouched; if none exist the input is returned as-is.
 pub(super) fn remove_trailing_break_force_newline(ftml: &str) -> String {
+    let re_ignore_when_no_footnote = Regex::new(r"(?is)\[\[footnote]].*?\[\[/footnote]]").unwrap();
+
+    if !re_ignore_when_no_footnote.is_match(ftml) {
+        return ftml.to_string();
+    }
+
     match ftml.rfind("@@@@") {
         Some(index) => {
             let mut output = String::with_capacity(ftml.len());
@@ -17,22 +25,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn removes_the_only_token() {
-        assert_eq!(remove_trailing_break_force_newline("a@@@@b"), "ab");
-    }
+    fn test_remove_trailing_break_force_newline() {
+        assert_eq!(
+            remove_trailing_break_force_newline("a\n\n\n\n\nb"),
+            "a\n\n\n\n\nb"
+        );
 
-    #[test]
-    fn removes_only_the_last_token() {
-        assert_eq!(remove_trailing_break_force_newline("@@@@x@@@@y"), "@@@@xy");
-    }
+        assert_eq!(
+            remove_trailing_break_force_newline("a\n@@@@\n@@@@\nb"),
+            "a\n@@@@\n@@@@\nb"
+        );
 
-    #[test]
-    fn leaves_string_without_token_unchanged() {
-        assert_eq!(remove_trailing_break_force_newline("abc"), "abc");
-    }
-
-    #[test]
-    fn removes_trailing_token() {
-        assert_eq!(remove_trailing_break_force_newline("a\n@@@@"), "a\n");
+        assert_eq!(
+            remove_trailing_break_force_newline(
+                "a[[footnote]]a[[/footnote]]\n@@@@\n@@@@\n@@@@\nb\n@@@@"
+            ),
+            "a[[footnote]]a[[/footnote]]\n@@@@\n@@@@\n@@@@\nb\n"
+        );
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,11 +2,13 @@
 import TopBar from "./components/editor/TopBar.vue";
 import "./styles/global.css";
 import EditorCanvas from "./components/editor/EditorCanvas.vue";
+import InputWindow from "./components/editor/InputWindow.vue";
 </script>
 
 <template>
     <TopBar />
     <EditorCanvas />
+    <InputWindow />
 </template>
 
 <style scoped></style>

--- a/src/components/editor/InputWindow.vue
+++ b/src/components/editor/InputWindow.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+import { nextTick, ref, watch } from "vue";
+import {
+    inputWindowState,
+    resolveInputWindow,
+} from "../../stores/inputWindow.ts";
+
+const value = ref("");
+const inputRef = ref<HTMLInputElement | null>(null);
+
+// Remember whatever held focus before the dialog opened so we can restore it
+// when the dialog closes.
+let previouslyFocused: HTMLElement | null = null;
+
+watch(
+    () => inputWindowState.visible,
+    (visible) => {
+        if (visible) {
+            previouslyFocused =
+                document.activeElement instanceof HTMLElement
+                    ? document.activeElement
+                    : null;
+            value.value = inputWindowState.defaultValue;
+            nextTick(() => {
+                inputRef.value?.focus();
+                inputRef.value?.select();
+            });
+        } else {
+            previouslyFocused?.focus();
+            previouslyFocused = null;
+        }
+    },
+);
+
+function confirm() {
+    // Empty input is treated as a cancel, matching the previous prompt() flow
+    // where an empty value inserted nothing.
+    resolveInputWindow(value.value.trim() || null);
+}
+
+function cancel() {
+    resolveInputWindow(null);
+}
+</script>
+
+<template>
+    <Teleport to="body">
+        <div
+            v-if="inputWindowState.visible"
+            class="input-window-backdrop"
+            @pointerdown.self="cancel"
+        >
+            <div
+                class="input-window"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="input-window-title"
+                @keydown.esc.prevent="cancel"
+            >
+                <div class="input-window-accent" aria-hidden="true"></div>
+                <div class="input-window-body">
+                    <h2 id="input-window-title" class="input-window-title">
+                        {{ inputWindowState.title }}
+                    </h2>
+                    <label
+                        v-if="inputWindowState.label"
+                        class="input-window-label"
+                        for="input-window-field"
+                    >
+                        {{ inputWindowState.label }}
+                    </label>
+                    <input
+                        id="input-window-field"
+                        ref="inputRef"
+                        v-model="value"
+                        class="input-window-field"
+                        type="text"
+                        :placeholder="inputWindowState.placeholder"
+                        autocomplete="off"
+                        spellcheck="false"
+                        @keydown.enter.prevent="confirm"
+                    />
+                    <div class="input-window-actions">
+                        <button
+                            type="button"
+                            class="input-window-button is-secondary"
+                            @click="cancel"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            class="input-window-button is-primary"
+                            @click="confirm"
+                        >
+                            {{ inputWindowState.confirmText }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </Teleport>
+</template>
+
+<style scoped>
+.input-window-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(17, 24, 39, 0.45);
+}
+
+.input-window {
+    width: min(420px, 100%);
+    overflow: hidden;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.25);
+    font-family: var(--font-ui);
+    animation: input-window-in 0.12s ease;
+}
+
+/* The single bit of color: a thin Word-blue strip at the top of the dialog. */
+.input-window-accent {
+    height: 3px;
+    background: var(--color-word-blue);
+}
+
+.input-window-body {
+    padding: 18px 20px 16px;
+}
+
+.input-window-title {
+    margin: 0 0 12px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--color-text-main);
+}
+
+.input-window-label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--context-menu-muted);
+}
+
+.input-window-field {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    background: var(--color-bg-surface);
+    color: var(--color-text-main);
+    font-family: inherit;
+    font-size: 14px;
+    outline: none;
+}
+
+.input-window-field:focus {
+    border-color: var(--color-word-blue);
+    box-shadow: 0 0 0 2px var(--color-word-blue-light);
+}
+
+.input-window-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 18px;
+}
+
+.input-window-button {
+    min-width: 76px;
+    padding: 7px 14px;
+    border-radius: 3px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.input-window-button:focus-visible {
+    outline: 2px solid var(--color-word-blue);
+    outline-offset: 2px;
+}
+
+.input-window-button.is-secondary {
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-surface);
+    color: var(--color-text-main);
+}
+
+.input-window-button.is-secondary:hover {
+    background: var(--button-hover);
+}
+
+.input-window-button.is-primary {
+    border: 1px solid var(--color-word-blue);
+    background: var(--color-word-blue);
+    color: var(--color-text-on-blue);
+}
+
+.input-window-button.is-primary:hover {
+    background: var(--color-word-blue-dark);
+    border-color: var(--color-word-blue-dark);
+}
+
+@keyframes input-window-in {
+    from {
+        transform: translateY(-6px);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .input-window {
+        animation: none;
+    }
+}
+</style>

--- a/src/stores/btnToolBar/btnFormats/btnURL.ts
+++ b/src/stores/btnToolBar/btnFormats/btnURL.ts
@@ -1,4 +1,5 @@
 import { getEditor } from "../../editor.ts";
+import { promptInput } from "../../inputWindow.ts";
 
 // This function is used to normalize URLs which entered by user but without `http` or `https` begin
 function normalizeUrl(url: string) {
@@ -102,12 +103,16 @@ export function insertEditorLink(rawUrl: string, options: LinkOptions = {}) {
         .run();
 }
 
-export function promptEditorLink(options: LinkOptions = {}) {
+export async function promptEditorLink(options: LinkOptions = {}) {
     const currentHref = getCurrentEditorLinkHref();
-    const url = window.prompt(
-        options.promptLabel ?? "Enter URL",
-        currentHref ?? "",
-    );
+    const title = options.promptLabel ?? "Insert link";
+    const url = await promptInput({
+        title,
+        label: title,
+        defaultValue: currentHref ?? "",
+        placeholder: options.leadingSlash ? "page-name" : "https://…",
+        confirmText: "Insert",
+    });
 
     if (url === null) {
         return;

--- a/src/stores/btnToolBar/btnInsertion/btnInsertImage.ts
+++ b/src/stores/btnToolBar/btnInsertion/btnInsertImage.ts
@@ -1,6 +1,7 @@
 import type { JSONContent } from "@tiptap/core";
 
 import { getEditor } from "../../editor.ts";
+import { promptInput } from "../../inputWindow.ts";
 
 export function isSupportedImageUrl(url: string) {
     return /^https?:\/\//i.test(url);
@@ -42,8 +43,13 @@ export function insertEditorImage(rawUrl: string) {
     editor.chain().focus().insertContent(createImageContent(src)).run();
 }
 
-export function promptEditorImage() {
-    const url = window.prompt("Enter image URL");
+export async function promptEditorImage() {
+    const url = await promptInput({
+        title: "Insert image",
+        label: "Image URL",
+        placeholder: "https://…",
+        confirmText: "Insert",
+    });
 
     if (url === null) {
         return;

--- a/src/stores/btnToolBar/btnInsertion/btnInsertImageBlock.ts
+++ b/src/stores/btnToolBar/btnInsertion/btnInsertImageBlock.ts
@@ -1,6 +1,7 @@
 import type { JSONContent } from "@tiptap/core";
 
 import { getEditor } from "../../editor.ts";
+import { promptInput } from "../../inputWindow.ts";
 import {
     alertUnsupportedImageUrl,
     isSupportedImageUrl,
@@ -70,8 +71,13 @@ export function insertEditorImageBlock(rawUrl: string) {
     editor.chain().focus().insertContent(createImageBlockContent(src)).run();
 }
 
-export function promptEditorImageBlock() {
-    const url = window.prompt("Enter image URL");
+export async function promptEditorImageBlock() {
+    const url = await promptInput({
+        title: "Insert image block",
+        label: "Image URL",
+        placeholder: "https://…",
+        confirmText: "Insert",
+    });
 
     if (url === null) {
         return;

--- a/src/stores/inputWindow.ts
+++ b/src/stores/inputWindow.ts
@@ -1,0 +1,65 @@
+import { reactive } from "vue";
+
+// macOS bundled Tauri (WKWebView) does not implement `window.prompt()`, so the
+// native call silently returns null and no dialog appears. This store backs a
+// custom in-app modal (`InputWindow.vue`) and exposes a promise-based
+// `promptInput()` that preserves the same `null`-means-cancel contract as the
+// native prompt.
+
+export interface InputWindowOptions {
+    title?: string; // dialog heading, e.g. "Insert link"
+    label?: string; // field label, e.g. "URL"
+    placeholder?: string; // input placeholder example
+    defaultValue?: string; // prefill (e.g. current link href)
+    confirmText?: string; // primary button text, e.g. "Insert"
+}
+
+interface InputWindowState extends Required<InputWindowOptions> {
+    visible: boolean;
+}
+
+export const inputWindowState = reactive<InputWindowState>({
+    visible: false,
+    title: "Enter value",
+    label: "",
+    placeholder: "",
+    defaultValue: "",
+    confirmText: "OK",
+});
+
+let resolver: ((value: string | null) => void) | null = null;
+
+// Opens the modal and resolves to the entered value, or null on cancel.
+export function promptInput(
+    options: InputWindowOptions = {},
+): Promise<string | null> {
+    // If a previous prompt is somehow still pending, cancel it so its promise
+    // never dangles.
+    if (resolver) {
+        const previous = resolver;
+        resolver = null;
+        previous(null);
+    }
+
+    inputWindowState.title = options.title ?? "Enter value";
+    inputWindowState.label = options.label ?? "";
+    inputWindowState.placeholder = options.placeholder ?? "";
+    inputWindowState.defaultValue = options.defaultValue ?? "";
+    inputWindowState.confirmText = options.confirmText ?? "OK";
+    inputWindowState.visible = true;
+
+    return new Promise<string | null>((resolve) => {
+        resolver = resolve;
+    });
+}
+
+// Called by InputWindow.vue to close the modal and settle the pending promise.
+export function resolveInputWindow(value: string | null) {
+    inputWindowState.visible = false;
+
+    if (resolver) {
+        const resolve = resolver;
+        resolver = null;
+        resolve(value);
+    }
+}


### PR DESCRIPTION
## Description

This PR relates on issue, to fix macOS only bug

Closes #98 

---

## Type of change

- [x] Bug fix
- [x] New feature / Wikidot node support
- [x] Exporter / parser change

---

## Checklist

- [x] `cargo check --workspace` passes
- [x] Export output tested against relevant Wikidot syntax (paste input/output below if applicable)
- [x] No inline SQL added — `.sql` files used throughout
- [x] No unnecessary dependencies added
- [x] `wj-*` attributes and round-trip behavior preserved (if touching TipTap node extensions)

---

## Export behavior

**Does this PR change or break existing Wikidot export output?**

- [x] Yes — describe what changed and why below

Add customize input window to fix macOS `window.prompt()` could not be shown after bundle.

_I don't know why macOS WebKit is so......unreliable_

<img width="808" height="639" alt="image" src="https://github.com/user-attachments/assets/6af6657e-5ce8-43f9-8fef-3f9da641d45e" />
