### PR TITLE
fix footnote sub editor marks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
       - dependency-name: "vue"
       - dependency-name: "vue-tsc"
       - dependency-name: "sass"
+      - dependency-name: "@codemirror/*"
+      - dependency-name: "public/code_view/eslint"
 
   # Code View subproject
   - package-ecosystem: "npm"
@@ -31,6 +33,7 @@ updates:
     ignore:
       - dependency-name: "time"
       - dependency-name: "rusqlite"
+      - dependency-name: "env_logger"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/src/components/editor/ToolBar/Formats/FormatCleaner.vue
+++ b/src/components/editor/ToolBar/Formats/FormatCleaner.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import FormatCleaner from "../../../../assets/icons/FormatCleaner.svg";
 import { getEditor } from "../../../../stores/editor/instance.ts";
+import { clearFootnoteMarks } from "../../../../stores/editor/extensions/WJtags/footnoteActiveView.ts";
 
 function formatCleaner() {
+    if (clearFootnoteMarks()) return;
+
     const editor = getEditor();
     if (!editor) return;
 

--- a/src/stores/btnToolBar/activeFormats.ts
+++ b/src/stores/btnToolBar/activeFormats.ts
@@ -1,6 +1,8 @@
 import { reactive } from "vue";
 import type { Editor } from "@tiptap/core";
+import type { EditorView } from "@tiptap/pm/view";
 import { type EditorTextAlign } from "../editor.ts";
+import { getActiveFootnoteView } from "../editor/extensions/WJtags/footnoteActiveView.ts";
 
 /**
  * Word-style toolbar state: which formats the caret currently sits inside.
@@ -58,7 +60,52 @@ function readBlockAlign(editor: Editor): EditorTextAlign | null {
     return null;
 }
 
+// Whether `markName` is active in the inner footnote view's selection.
+function isFootnoteMarkActive(view: EditorView, markName: string): boolean {
+    const markType = view.state.schema.marks[markName];
+
+    if (!markType) {
+        return false;
+    }
+
+    const { from, to, empty, $from } = view.state.selection;
+
+    if (empty) {
+        const marks = view.state.storedMarks ?? $from.marks();
+
+        return Boolean(markType.isInSet(marks));
+    }
+
+    return view.state.doc.rangeHasMark(from, to, markType);
+}
+
+// While a footnote sub-editor is open, the outer selection is a NodeSelection
+// over the whole footnote, so the highlight flags must come from the inner
+// view. Block formats (lists/quote/align) can't live in a footnote's `text*`
+// content, so they read as off.
+function refreshFootnoteFormats(view: EditorView) {
+    activeFormats.bold = isFootnoteMarkActive(view, "bold");
+    activeFormats.italic = isFootnoteMarkActive(view, "italic");
+    activeFormats.underline = isFootnoteMarkActive(view, "underline");
+    activeFormats.strike = isFootnoteMarkActive(view, "strike");
+    activeFormats.subscript = isFootnoteMarkActive(view, "subscript");
+    activeFormats.superscript = isFootnoteMarkActive(view, "superscript");
+    activeFormats.blockquote = false;
+    activeFormats.orderedList = false;
+    activeFormats.bulletList = false;
+    activeFormats.alignLeft = true;
+    activeFormats.alignCenter = false;
+    activeFormats.alignRight = false;
+}
+
 function refreshActiveFormats(editor: Editor) {
+    const footnoteView = getActiveFootnoteView();
+
+    if (footnoteView) {
+        refreshFootnoteFormats(footnoteView);
+        return;
+    }
+
     activeFormats.bold = editor.isActive("bold");
     activeFormats.italic = editor.isActive("italic");
     activeFormats.underline = editor.isActive("underline");

--- a/src/stores/btnToolBar/btnFormats/btnBasic.ts
+++ b/src/stores/btnToolBar/btnFormats/btnBasic.ts
@@ -1,22 +1,43 @@
 import { getEditor } from "../../editor.ts";
+import { toggleFootnoteMark } from "../../editor/extensions/WJtags/footnoteActiveView.ts";
 
 export function toggleEditorBold() {
+    if (toggleFootnoteMark("bold")) {
+        return;
+    }
+
     getEditor()?.chain().focus().toggleMark("bold").run();
 }
 
 export function toggleEditorItalic() {
+    if (toggleFootnoteMark("italic")) {
+        return;
+    }
+
     getEditor()?.chain().focus().toggleMark("italic").run();
 }
 
 export function toggleEditorUnderline() {
+    if (toggleFootnoteMark("underline")) {
+        return;
+    }
+
     getEditor()?.chain().focus().toggleMark("underline").run();
 }
 
 export function toggleEditorStrikethrough() {
+    if (toggleFootnoteMark("strike")) {
+        return;
+    }
+
     getEditor()?.chain().focus().toggleMark("strike").run();
 }
 
 export function toggleEditorSubscript() {
+    if (toggleFootnoteMark("subscript", "superscript")) {
+        return;
+    }
+
     getEditor()
         ?.chain()
         .focus()
@@ -26,6 +47,10 @@ export function toggleEditorSubscript() {
 }
 
 export function toggleEditorSuperscript() {
+    if (toggleFootnoteMark("superscript", "subscript")) {
+        return;
+    }
+
     getEditor()
         ?.chain()
         .focus()

--- a/src/stores/btnToolBar/btnFormats/btnColor.ts
+++ b/src/stores/btnToolBar/btnFormats/btnColor.ts
@@ -1,6 +1,11 @@
 import { getEditor } from "../../editor.ts";
+import { setFootnoteMark } from "../../editor/extensions/WJtags/footnoteActiveView.ts";
 
 export function setEditorTextColor(color: string) {
+    if (setFootnoteMark("textColor", { color })) {
+        return;
+    }
+
     getEditor()?.chain().focus().setMark("textColor", { color }).run();
 }
 

--- a/src/stores/btnToolBar/btnFormats/btnSize.ts
+++ b/src/stores/btnToolBar/btnFormats/btnSize.ts
@@ -1,4 +1,8 @@
 import { getEditor } from "../../editor.ts";
+import {
+    addFontSizeOverSelection,
+    getActiveFootnoteFontSize,
+} from "../../editor/extensions/WJtags/footnoteActiveView.ts";
 import type { Level } from "@tiptap/extension-heading";
 
 const defaultFontSize = 16;
@@ -7,7 +11,8 @@ const minFontSize = 8;
 const maxFontSize = 72;
 
 function getCurrentFontSize() {
-    const size = getEditor()?.getAttributes("fontSize").size;
+    const size =
+        getActiveFootnoteFontSize() ?? getEditor()?.getAttributes("fontSize").size;
 
     if (typeof size !== "string") {
         return defaultFontSize;
@@ -22,6 +27,12 @@ function normalizeFontSize(size: number) {
 }
 
 export function setEditorFontSize(size: number) {
+    if (
+        addFontSizeOverSelection({ size: `${normalizeFontSize(size)}px` })
+    ) {
+        return;
+    }
+
     const editor = getEditor();
     const markType = editor?.schema.marks.fontSize;
 

--- a/src/stores/editor/extensions/WJtags/FootnoteE.ts
+++ b/src/stores/editor/extensions/WJtags/FootnoteE.ts
@@ -23,6 +23,10 @@ import { StepMap } from "@tiptap/pm/transform";
 import { EditorView } from "@tiptap/pm/view";
 import { keymap } from "@tiptap/pm/keymap";
 import { undo, redo } from "@tiptap/pm/history";
+import {
+    setActiveFootnoteView,
+    clearActiveFootnoteView,
+} from "./footnoteActiveView.ts";
 
 declare module "@tiptap/core" {
     interface Commands<ReturnType> {
@@ -98,9 +102,17 @@ class FootnoteView {
                 },
             },
         });
+
+        // Register this inner view so toolbar style commands target its
+        // selection instead of the outer NodeSelection over the whole footnote.
+        setActiveFootnoteView(this.innerView);
     }
 
     close() {
+        if (this.innerView) {
+            clearActiveFootnoteView(this.innerView);
+        }
+
         this.innerView?.destroy();
         this.innerView = null;
         this.dom.textContent = "";

--- a/src/stores/editor/extensions/WJtags/footnoteActiveView.ts
+++ b/src/stores/editor/extensions/WJtags/footnoteActiveView.ts
@@ -1,0 +1,198 @@
+// Registry + styling helpers for the footnote sub-editor.
+//
+// A footnote is edited inside a nested ProseMirror `EditorView` (see
+// FootnoteE.ts). While that inner view is open, the *outer* editor's selection
+// is a NodeSelection covering the whole footnote node, so toolbar style
+// commands dispatched to the main editor restyle the entire footnote line.
+//
+// This module tracks the currently-open inner view and exposes helpers that
+// apply inline-mark styles to its own text selection instead. Inner steps are
+// mapped back onto the outer document by FootnoteView.dispatchInner, so no
+// node-spec or serialization changes are needed.
+//
+// Every helper returns `true` when it handled the action (a footnote sub-editor
+// is open) so callers can fall through to the main editor otherwise. Note it
+// returns `true` even when the requested mark type is missing — that is
+// deliberate, to avoid falling through and restyling the whole node.
+import { toggleMark } from "@tiptap/pm/commands";
+import type { MarkType } from "@tiptap/pm/model";
+import type { EditorView } from "@tiptap/pm/view";
+
+let activeFootnoteView: EditorView | null = null;
+
+export function setActiveFootnoteView(view: EditorView) {
+    activeFootnoteView = view;
+}
+
+// Only clears when the passed view is the one stored. When a footnote is
+// clicked while another is open, the new footnote's `open()` may run before the
+// previous footnote's `close()` during the same selection update; this guard
+// stops the stale `close()` from wiping the freshly-registered view.
+export function clearActiveFootnoteView(view: EditorView) {
+    if (activeFootnoteView === view) {
+        activeFootnoteView = null;
+    }
+}
+
+export function getActiveFootnoteView(): EditorView | null {
+    return activeFootnoteView;
+}
+
+// Removes `markType` from the current selection (used to enforce sub/sup mutual
+// exclusion before toggling the other on).
+function removeMarkFromSelection(view: EditorView, markType: MarkType) {
+    const { from, to, empty } = view.state.selection;
+
+    if (empty) {
+        if (markType.isInSet(view.state.storedMarks ?? [])) {
+            view.dispatch(view.state.tr.removeStoredMark(markType));
+        }
+
+        return;
+    }
+
+    view.dispatch(view.state.tr.removeMark(from, to, markType));
+}
+
+export function toggleFootnoteMark(
+    markName: string,
+    excludesMarkName?: string,
+): boolean {
+    const view = getActiveFootnoteView();
+
+    if (!view) {
+        return false;
+    }
+
+    const markType = view.state.schema.marks[markName];
+
+    if (!markType) {
+        return true;
+    }
+
+    if (excludesMarkName) {
+        const excludesType = view.state.schema.marks[excludesMarkName];
+
+        if (excludesType) {
+            removeMarkFromSelection(view, excludesType);
+        }
+    }
+
+    toggleMark(markType)(view.state, (tr) => view.dispatch(tr));
+    view.focus();
+
+    return true;
+}
+
+export function setFootnoteMark(
+    markName: string,
+    attrs: Record<string, unknown>,
+): boolean {
+    const view = getActiveFootnoteView();
+
+    if (!view) {
+        return false;
+    }
+
+    const markType = view.state.schema.marks[markName];
+
+    if (!markType) {
+        return true;
+    }
+
+    const { from, to, empty } = view.state.selection;
+    const mark = markType.create(attrs);
+
+    if (empty) {
+        view.dispatch(view.state.tr.addStoredMark(mark));
+    } else {
+        view.dispatch(view.state.tr.addMark(from, to, mark));
+    }
+
+    view.focus();
+
+    return true;
+}
+
+export function addFontSizeOverSelection(
+    attrs: Record<string, unknown>,
+): boolean {
+    const view = getActiveFootnoteView();
+
+    if (!view) {
+        return false;
+    }
+
+    const markType = view.state.schema.marks.fontSize;
+
+    if (!markType) {
+        return true;
+    }
+
+    const { from, to } = view.state.selection;
+    const tr = view.state.tr;
+    const mark = markType.create(attrs);
+    let applied = false;
+
+    tr.doc.nodesBetween(from, to, (node, pos) => {
+        if (!node.isText) {
+            return;
+        }
+
+        tr.addMark(pos, pos + node.nodeSize, mark);
+        applied = true;
+    });
+
+    if (applied) {
+        view.dispatch(tr);
+        view.focus();
+    }
+
+    return true;
+}
+
+// Reads the fontSize attr from the active footnote selection so the
+// increase/decrease buttons step from the footnote's current value. Returns
+// `null` when no footnote is open or no fontSize mark is present.
+export function getActiveFootnoteFontSize(): string | null {
+    const view = getActiveFootnoteView();
+
+    if (!view) {
+        return null;
+    }
+
+    const markType = view.state.schema.marks.fontSize;
+
+    if (!markType) {
+        return null;
+    }
+
+    const { from, $from, empty } = view.state.selection;
+    const marks = empty
+        ? view.state.storedMarks ?? $from.marks()
+        : view.state.doc.resolve(from).marks();
+    const mark = marks.find((candidate) => candidate.type === markType);
+    const size = mark?.attrs.size;
+
+    return typeof size === "string" ? size : null;
+}
+
+export function clearFootnoteMarks(): boolean {
+    const view = getActiveFootnoteView();
+
+    if (!view) {
+        return false;
+    }
+
+    const { from, to, empty } = view.state.selection;
+
+    if (empty) {
+        view.dispatch(view.state.tr.setStoredMarks([]));
+    } else {
+        view.dispatch(view.state.tr.removeMark(from, to));
+    }
+
+    view.focus();
+
+    return true;
+}


### PR DESCRIPTION
## Description

Fixed footnote sub-editor's marks insertion issue. Only frontend change, no backend change, also update dependabot settings.

Closes #102 #103 

---

## Type of change

- [x] Bug fix
- [x] chore

---

## Checklist

- [x] `cargo check --workspace` passes
- [x] Export output tested against relevant Wikidot syntax (paste input/output below if applicable)
- [x] No unnecessary dependencies added

---

## Export behavior

**Does this PR change or break existing Wikidot export output?**

- [x] No

### Notes

<img width="530" height="129" alt="image" src="https://github.com/user-attachments/assets/56a5c57e-c1dc-440f-9dcb-24c8846cea8d" />

The legacy version of footnote sub-editor only renders full line marks when user insert `Bold`, `Italic` etc.

Fixed it by adding marks in footnote sub-editor configurations in `footnoteActiveView.ts`, and update the insert pipeline in `activeFormats.ts`
